### PR TITLE
Add deployment automation and simplify basic-app-ts to JWT-only auth

### DIFF
--- a/basic-app-ts/README.md
+++ b/basic-app-ts/README.md
@@ -1,0 +1,73 @@
+# Basic TypeScript App Sample
+
+A simple TypeScript application for Azure Confidential Ledger demonstrating user-defined endpoints with JWT authentication.
+
+## Overview
+
+This sample implements a basic echo endpoint that receives a string value and returns it, showcasing how to build and deploy custom applications to Azure Confidential Ledger.
+
+## Prerequisites
+
+- Node.js v22+ and npm
+- Azure CLI (logged in with `az login`)
+- Python 3.x
+- An existing Azure Confidential Ledger instance with AAD-based authentication
+
+## Quick Start
+
+### 1. Deploy the Application
+
+```bash
+python build_and_deploy.py
+```
+
+This script will:
+- Install npm dependencies
+- Build the TypeScript application using Rollup
+- Deploy the bundle to your Azure Confidential Ledger
+- Save configuration for testing
+
+You'll be prompted for:
+- Azure subscription confirmation
+- Ledger name (must already exist)
+- Resource group name
+
+### 2. Test Interactively
+
+```bash
+python test_interactive.py
+```
+
+This opens an interactive session where you can:
+- Send test values to the echo endpoint
+- See responses in real-time
+- Type `quit` to exit
+
+## Application Structure
+
+- **src/endpoints/app.ts** - Echo endpoint handler
+- **app.json** - Endpoint configuration with JWT authentication
+- **build_and_deploy.py** - Build and deployment script
+- **test_interactive.py** - Interactive testing script
+
+## Authentication
+
+This sample uses Azure AD token authentication (JWT). Tokens are automatically obtained using `az account get-access-token`.
+
+## API Endpoint
+
+**POST** `/app/echo`
+
+Request body:
+```json
+{
+  "value": "your string here"
+}
+```
+
+Response:
+```json
+{
+  "echoed_value": "your string here"
+}
+```

--- a/basic-app-ts/app.json
+++ b/basic-app-ts/app.json
@@ -5,7 +5,7 @@
         "js_module": "endpoints/app.js",
         "js_function": "echo_handler",
         "forwarding_required": "always",
-        "authn_policies": ["any_cert"],
+        "authn_policies": ["jwt"],
         "openapi": {
           "security": [],
           "parameters": [],

--- a/basic-app-ts/build_and_deploy.py
+++ b/basic-app-ts/build_and_deploy.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Deployment script for basic-app-ts
+Builds the TypeScript app and deploys it to Azure Confidential Ledger
+"""
+
+import subprocess
+import sys
+import os
+import json
+import tempfile
+from pathlib import Path
+
+def run_command(cmd, cwd=None, check=True):
+    """Run a shell command and return the result"""
+    print(f"Running: {cmd}")
+    result = subprocess.run(
+        cmd,
+        shell=True,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False
+    )
+    
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr and result.returncode != 0:
+        print(f"Error: {result.stderr}", file=sys.stderr)
+    
+    if check and result.returncode != 0:
+        print(f"Command failed with exit code {result.returncode}")
+        sys.exit(1)
+    
+    return result
+
+def check_prerequisites():
+    """Check if required tools are installed"""
+    print("\n=== Checking Prerequisites ===")
+    
+    required_tools = {
+        'node': 'node --version',
+        'npm': 'npm --version',
+        'az': 'az --version',
+    }
+    
+    missing_tools = []
+    for tool, check_cmd in required_tools.items():
+        result = run_command(check_cmd, check=False)
+        if result.returncode != 0:
+            missing_tools.append(tool)
+            print(f"❌ {tool} not found")
+        else:
+            print(f"✅ {tool} found")
+    
+    # Check for openssl - try multiple locations on Windows
+    openssl_found = False
+    openssl_paths = [
+        'openssl',  # In PATH
+        r'C:\Program Files\Git\usr\bin\openssl.exe',  # Git Bash
+        r'C:\Program Files (x86)\Git\usr\bin\openssl.exe',  # Git Bash 32-bit
+    ]
+    
+    for openssl_cmd in openssl_paths:
+        result = run_command(f'"{openssl_cmd}" version', check=False)
+        if result.returncode == 0:
+            openssl_found = True
+            print(f"✅ openssl found")
+            globals()['OPENSSL_CMD'] = openssl_cmd
+            break
+    
+    if not openssl_found:
+        missing_tools.append('openssl')
+        print(f"❌ openssl not found")
+        print("   Try: choco install openssl")
+        print("   Or install Git for Windows which includes OpenSSL")
+    
+    if missing_tools:
+        print(f"\n❌ Missing required tools: {', '.join(missing_tools)}")
+        print("Please install them before continuing.")
+        sys.exit(1)
+    
+    print("\n✅ All prerequisites satisfied!\n")
+
+def build_app():
+    """Build the TypeScript application"""
+    print("\n=== Building Application ===")
+    
+    script_dir = Path(__file__).parent
+    
+    print("Installing npm dependencies...")
+    run_command("npm install", cwd=script_dir)
+    
+    print("\nBuilding application...")
+    run_command("npm run build", cwd=script_dir)
+    
+    bundle_path = script_dir / "dist" / "bundle.json"
+    if not bundle_path.exists():
+        print(f"❌ Build failed: {bundle_path} not found")
+        sys.exit(1)
+    
+    print(f"✅ Build successful! Bundle created at: {bundle_path}\n")
+    return bundle_path
+
+def get_user_input():
+    """Get deployment configuration from user"""
+    print("\n=== Deployment Configuration ===")
+    
+    # Check if user is logged into Azure
+    result = run_command("az account show", check=False)
+    if result.returncode != 0:
+        print("❌ Not logged into Azure. Please run: az login")
+        sys.exit(1)
+    
+    account_info = json.loads(result.stdout)
+    subscription_id = account_info['id']
+    tenant_id = account_info['tenantId']
+    
+    print(f"\nCurrent Azure subscription: {account_info['name']}")
+    print(f"Subscription ID: {subscription_id}")
+    print(f"Tenant ID: {tenant_id}")
+    
+    use_current = input("\nUse this subscription? (y/n): ").lower().strip()
+    if use_current != 'y':
+        print("Please run 'az account set --subscription <subscription-id>' to switch subscriptions")
+        sys.exit(0)
+    
+    ledger_name = input("\nEnter Azure Confidential Ledger name: ").strip()
+    if not ledger_name:
+        print("❌ Ledger name is required")
+        sys.exit(1)
+    
+    resource_group = input("Enter resource group name: ").strip()
+    if not resource_group:
+        print("❌ Resource group name is required")
+        sys.exit(1)
+    
+    config = {
+        'subscription_id': subscription_id,
+        'tenant_id': tenant_id,
+        'ledger_name': ledger_name,
+        'resource_group': resource_group
+    }
+    
+    return config
+
+def get_azure_token():
+    """Get Azure AD access token for Confidential Ledger"""
+    result = run_command(
+        'az account get-access-token --resource https://confidential-ledger.azure.com --query accessToken -o tsv',
+        check=False
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    return None
+
+def deploy_app(config, bundle_path, cert_path=None, key_path=None):
+    """Deploy the application bundle to the ledger"""
+    print("\n=== Deploying Application ===")
+    
+    ledger_url = f"https://{config['ledger_name']}.confidential-ledger.azure.com"
+    api_version = "2024-12-09-preview"
+    
+    print(f"Deploying to: {ledger_url}")
+    print(f"Auth method: Azure AD token")
+    
+    token = get_azure_token()
+    if not token:
+        print("❌ Failed to get Azure AD token")
+        return False
+    
+    cmd = (
+        f'curl -k -X PUT '
+        f'"{ledger_url}/app/userDefinedEndpoints?api-version={api_version}" '
+        f'-H "Content-Type: application/json" '
+        f'-H "Authorization: Bearer {token}" '
+        f'-d @{bundle_path} '
+        f'-s -o /dev/null -w "%{{http_code}}"'
+    )
+    
+    result = run_command(cmd, check=False)
+    status_code = result.stdout.strip()
+    
+    if status_code == "201":
+        print("✅ Application deployed successfully!\n")
+        return True
+    else:
+        print(f"❌ Deployment failed with status code: {status_code}")
+        if result.stderr:
+            print(f"Error details: {result.stderr}")
+        return False
+
+def save_config(config, cert_path=None, key_path=None):
+    """Save configuration for later use"""
+    script_dir = Path(__file__).parent
+    config_file = script_dir / ".deploy_config.json"
+    
+    save_data = {
+        'ledger_name': config['ledger_name'],
+        'resource_group': config['resource_group']
+    }
+    
+    with open(config_file, 'w') as f:
+        json.dump(save_data, f, indent=2)
+    
+    print(f"📝 Configuration saved to {config_file}")
+    print(f"   Use test_interactive.py to test the deployed app\n")
+
+def main():
+    """Main deployment workflow"""
+    print("=" * 60)
+    print("  Azure Confidential Ledger - Deploy Script")
+    print("=" * 60)
+    
+    try:
+        # Step 1: Check prerequisites
+        check_prerequisites()
+        
+        # Step 2: Build the app
+        bundle_path = build_app()
+        
+        # Step 3: Get user configuration
+        config = get_user_input()
+        
+        # Step 4: Deploy the app
+        if not deploy_app(config, bundle_path):
+            print("❌ Deployment failed")
+            sys.exit(1)
+        
+        # Step 6: Save config for testing
+        save_config(config)
+        
+        print("=" * 60)
+        print("  Deployment Complete!")
+        print("=" * 60)
+        print(f"\n✅ Ledger: {config['ledger_name']}")
+        print(f"✅ URL: https://{config['ledger_name']}.confidential-ledger.azure.com")
+        print(f"\n💡 Run 'python test_interactive.py' to test the application")
+        
+    except KeyboardInterrupt:
+        print("\n\n❌ Deployment cancelled by user")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/basic-app-ts/build_bundle.js
+++ b/basic-app-ts/build_bundle.js
@@ -1,0 +1,67 @@
+import { readdirSync, statSync, readFileSync, writeFileSync } from "fs";
+import { join, posix, sep } from "path";
+
+const args = process.argv.slice(2);
+
+const getAllFiles = function (dirPath, arrayOfFiles) {
+  arrayOfFiles = arrayOfFiles || [];
+
+  const files = readdirSync(dirPath);
+  for (const file of files) {
+    const filePath = join(dirPath, file);
+    if (statSync(filePath).isDirectory()) {
+      arrayOfFiles = getAllFiles(filePath, arrayOfFiles);
+    } else {
+      arrayOfFiles.push(filePath);
+    }
+  }
+
+  return arrayOfFiles;
+};
+
+const removePrefix = function (s, prefix) {
+  return s.substr(prefix.length).split(sep).join(posix.sep);
+};
+
+const rootDir = args[0];
+
+const metadataPath = join(rootDir, "app.json");
+const metadata = JSON.parse(readFileSync(metadataPath, "utf-8"));
+
+const srcDir = join(rootDir, "src");
+const allFiles = getAllFiles(srcDir);
+
+// The trailing / is included so that it is trimmed in removePrefix.
+// This produces "foo/bar.js" rather than "/foo/bar.js"
+const toTrim = srcDir + "/";
+
+const modules = allFiles.map(function (filePath) {
+  return {
+    name: removePrefix(filePath, toTrim),
+    module: readFileSync(filePath, "utf-8"),
+  };
+});
+
+const bundlePath = join(args[0], "bundle.json");
+const appRegPath = join(args[0], "set_js_app.json");
+const bundle = {
+  metadata: metadata,
+  modules: modules,
+};
+const app_reg = {
+  actions: [
+    {
+      name: "set_js_app",
+      args: {
+        bundle: bundle,
+        disable_bytecode_cache: false,
+      },
+    },
+  ],
+};
+
+console.log(
+  `Writing bundle containing ${modules.length} modules to ${bundlePath}`,
+);
+writeFileSync(bundlePath, JSON.stringify(bundle));
+writeFileSync(appRegPath, JSON.stringify(app_reg));

--- a/basic-app-ts/package-lock.json
+++ b/basic-app-ts/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@microsoft/ccf-app": "~/CCF/js/ccf-app/microsoft-ccf-app-0.0.0.tgz",
+        "@microsoft/ccf-app": "^6.0.14",
         "js-base64": "^3.5.2",
         "jsrsasign": "^11.0.0",
         "jsrsasign-util": "^1.0.2",
@@ -473,10 +473,13 @@
       }
     },
     "node_modules/@microsoft/ccf-app": {
-      "version": "0.0.0",
-      "resolved": "file:../../CCF/js/ccf-app/microsoft-ccf-app-0.0.0.tgz",
-      "integrity": "sha512-HTsukWvIoxppTlv4whfcAIzeoUFBc3E6uTVuBxN2/ZfEzznVEpPqAHujb835Xl2EiMRpsTXZwCDOfRuGmw+Y5w==",
-      "license": "Apache-2.0"
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/@microsoft/ccf-app/-/ccf-app-6.0.16.tgz",
+      "integrity": "sha512-oSSY0oSgWvnz7bKYwEvjar2Gd6EGaqKCdHY8S11vBWTJpQOwnQYCDYeARNGZpftL71TpSjJv390FDt/fJHzPXQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "ccf-build-bundle": "scripts/build_bundle.js"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/basic-app-ts/package.json
+++ b/basic-app-ts/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "scripts": {
-    "build": "del-cli -f dist/ && rollup --config && cp app.json dist/ && npm exec build_bundle -- dist"
+    "build": "del-cli -f dist/ && rollup --config && node -e \"require('fs').copyFileSync('app.json', 'dist/app.json')\" && node build_bundle.js dist/"
   },
   "type": "module",
   "engines": {
     "node": ">=16"
   },
   "dependencies": {
-    "@microsoft/ccf-app": "~/CCF/js/ccf-app/microsoft-ccf-app-0.0.0.tgz",
+    "@microsoft/ccf-app": "^6.0.14",
     "js-base64": "^3.5.2",
     "jsrsasign": "^11.0.0",
     "jsrsasign-util": "^1.0.2",

--- a/basic-app-ts/test_interactive.py
+++ b/basic-app-ts/test_interactive.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Interactive testing script for basic-app-ts
+Tests the deployed echo endpoint in interactive mode
+"""
+
+import subprocess
+import sys
+import os
+import json
+import tempfile
+from pathlib import Path
+
+def load_config():
+    """Load configuration from deploy script"""
+    script_dir = Path(__file__).parent
+    config_file = script_dir / ".deploy_config.json"
+    
+    if config_file.exists():
+        with open(config_file, 'r') as f:
+            return json.load(f)
+    return None
+
+def get_user_config():
+    """Get configuration from user"""
+    print("\n=== Configuration ===")
+    
+    # Try to load saved config
+    saved_config = load_config()
+    
+    if saved_config:
+        print(f"\n✅ Found saved configuration:")
+        print(f"   Ledger: {saved_config['ledger_name']}")
+        print(f"   Auth: Azure AD token")
+        
+        use_saved = input("\nUse saved configuration? (y/n): ").lower().strip()
+        if use_saved == 'y':
+            return saved_config
+    
+    # Manual configuration
+    print("\n⚙️  Manual configuration:")
+    
+    ledger_name = input("Enter Azure Confidential Ledger name: ").strip()
+    if not ledger_name:
+        print("❌ Ledger name is required")
+        sys.exit(1)
+    
+    return {'ledger_name': ledger_name}
+
+def get_azure_token():
+    """Get Azure AD access token for Confidential Ledger"""
+    result = subprocess.run(
+        'az account get-access-token --resource https://confidential-ledger.azure.com --query accessToken -o tsv',
+        shell=True,
+        capture_output=True,
+        text=True,
+        check=False
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    return None
+
+def call_echo_endpoint(config, value):
+    """Call the echo endpoint with a value"""
+    ledger_url = f"https://{config['ledger_name']}.confidential-ledger.azure.com"
+    
+    # Create a temporary JSON file for the data
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump({"value": value}, f)
+        test_data_file = f.name
+    
+    try:
+        token = get_azure_token()
+        if not token:
+            return None, "Failed to get Azure AD token. Run 'az login' first."
+        
+        cmd = (
+            f'curl -k -X POST '
+            f'"{ledger_url}/app/echo" '
+            f'-H "Content-Type: application/json" '
+            f'-H "Authorization: Bearer {token}" '
+            f'-d @{test_data_file} '
+            f'-s'
+        )
+        
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            check=False
+        )
+        
+        if result.returncode == 0 and result.stdout:
+            try:
+                response = json.loads(result.stdout)
+                return response, None
+            except json.JSONDecodeError:
+                return None, f"Invalid JSON response: {result.stdout}"
+        
+        return None, result.stderr or "Unknown error"
+    finally:
+        # Clean up the temp file
+        if os.path.exists(test_data_file):
+            os.unlink(test_data_file)
+
+def interactive_mode(config):
+    """Interactive mode for testing the echo endpoint"""
+    print("\n" + "=" * 60)
+    print("  Interactive Echo Mode")
+    print("=" * 60)
+    print(f"Ledger: {config['ledger_name']}")
+    print(f"Auth: Azure AD token")
+    print("\nType a message to echo (or 'quit' to exit)")
+    print()
+    
+    while True:
+        try:
+            user_input = input("Enter message: ").strip()
+            
+            if user_input.lower() in ['quit', 'exit', 'q']:
+                print("\n👋 Exiting...\n")
+                break
+            
+            if not user_input:
+                print("⚠️  Please enter a non-empty message\n")
+                continue
+            
+            print(f"📤 Sending: {user_input}")
+            response, error = call_echo_endpoint(config, user_input)
+            
+            if response:
+                echoed = response.get('echoed_value', '')
+                print(f"📥 Received: {echoed}")
+                if echoed == user_input:
+                    print("✅ Match!\n")
+                else:
+                    print("⚠️  Response doesn't match input\n")
+            else:
+                print(f"❌ Error: {error}\n")
+        
+        except KeyboardInterrupt:
+            print("\n\n👋 Exiting...\n")
+            break
+        except Exception as e:
+            print(f"❌ Error: {e}\n")
+
+def main():
+    """Main entry point"""
+    print("=" * 60)
+    print("  Azure Confidential Ledger - Interactive Test")
+    print("=" * 60)
+    
+    try:
+        # Get configuration
+        config = get_user_config()
+        
+        if not config:
+            print("❌ Failed to get configuration")
+            sys.exit(1)
+        
+        # Run initial test
+        print("\n=== Running Initial Test ===")
+        test_value = "Hello from basic-app-ts!"
+        print(f"Testing with: '{test_value}'")
+        
+        response, error = call_echo_endpoint(config, test_value)
+        
+        if response and response.get('echoed_value') == test_value:
+            print(f"✅ Connection successful!")
+            print(f"Response: {json.dumps(response, indent=2)}")
+        else:
+            print(f"❌ Connection failed")
+            if error:
+                print(f"Error: {error}")
+            sys.exit(1)
+        
+        # Enter interactive mode
+        interactive_mode(config)
+        
+    except KeyboardInterrupt:
+        print("\n\n❌ Cancelled by user")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add build_and_deploy.py: automated build and deploy script
- Add test_interactive.py: interactive echo endpoint testing
- Add build_bundle.js: bundle creation script
- Update app.json: switch to JWT-only authentication (remove certificate auth)
- Update package.json: fix Windows compatibility and use npm @microsoft/ccf-app
- Add README.md: comprehensive setup and usage documentation